### PR TITLE
Fix for legacy parsing bug

### DIFF
--- a/infrastructure.go
+++ b/infrastructure.go
@@ -56,8 +56,7 @@ func SetupLambdaInfrastructure() error {
 					return err
 				}
 				_, err = svc.PutRolePolicy(&iam.PutRolePolicyInput{
-					PolicyDocument: aws.String(`
-					{
+					PolicyDocument: aws.String(`{
 					  "Version": "2012-10-17",
 					  "Statement": [
 					    {


### PR DESCRIPTION
Error when running awslambdaproxy setup:

"Failed to run setup for awslambdaproxyMalformedPolicyDocument: The policy failed legacy parsing"

Since the assumeRoleDocument is still good the role will be created, but the function isn't able to write to CloudWatch Logs.  Removing the empty line at the beginning of the policy fixes it.